### PR TITLE
Introduce docker-compose environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,42 @@
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+COMPOSEFILE := $(PROJECT_PATH)/compose/docker-compose.yaml
+DOCKER_COMPOSE := docker-compose -f $(COMPOSEFILE)
+OPEN_APP ?= xdg-open
+
+.PHONY: fetch-protos help up stop status top kill down proxy-info proxy
+
+# Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 fetch_protos: ## Fetch protobuf files
 	$(Q) git submodule update --init --recursive
 
-# Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+up: ## Start docker-compose containers
+	$(DOCKER_COMPOSE) up
+
+stop: ## Stop docker-compose containers
+	$(DOCKER_COMPOSE) stop
+
+status: ## Status of docker-compose containers
+	$(DOCKER_COMPOSE) ps
+
+top: ## Show runtime information about docker-compose containers
+	$(DOCKER_COMPOSE) top
+
+kill: ## Force-stop docker-compose containers
+	$(DOCKER_COMPOSE) kill
+
+down: ## Stop and remove containers and other docker-compose resources
+	$(DOCKER_COMPOSE) down
+
+proxy-info: export INDEX?=1
+proxy-info: ## Obtain the local host address and port for a service (use SERVICE, PORT and optionally INDEX)
+	$(DOCKER_COMPOSE) port --index $(INDEX) $(SERVICE) $(PORT)
+
+proxy: export INDEX?=1
+proxy: export SCHEME?=http
+proxy: LOCALURL=$(shell $(DOCKER_COMPOSE) port --index $(INDEX) $(SERVICE) $(PORT))
+proxy: ## Open service and port in a browser (same as proxy-info, but optionally define SCHEME and OPEN_APP)
+	$(OPEN_APP) $(SCHEME)://$(LOCALURL)

--- a/compose/control-plane/Dockerfile
+++ b/compose/control-plane/Dockerfile
@@ -1,0 +1,34 @@
+FROM rust AS build
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update -y \
+ && apt-get -y dist-upgrade \
+ && rustup component add rustfmt
+
+WORKDIR /usr/src/gateway-ng-controller
+
+COPY Cargo.* ./
+
+RUN mkdir -p src \
+ && echo "fn main() -> Result<(), u8> { eprintln!(\"if you see this, the build broke\"); Err(1) }" > src/main.rs \
+ && cargo build --release \
+ && rm -f target/release/deps/gateway-ng-controller*
+
+COPY . .
+
+RUN cargo build --release
+
+FROM debian
+
+WORKDIR /home/app/bin
+ENV PATH="/home/app/bin:${PATH}"
+
+COPY --from=build /usr/src/gateway-ng-controller/target/release/gateway-ng-controller .
+
+RUN chown -R 1001:1001 /home/app
+
+EXPOSE 5000
+
+USER 1001:1001
+
+CMD ./gateway-ng-controller

--- a/compose/control-plane/config.json
+++ b/compose/control-plane/config.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 1,
+    "hosts": ["web"],
+    "policies": [],
+    "target_domain": "web.app:80"
+  }
+]

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -1,0 +1,70 @@
+version: "2.2"
+services:
+  ingress:
+    image: istio/proxyv2:1.7.2
+    entrypoint: /bin/bash -c '/usr/local/bin/envoy -c /etc/envoy.yaml --service-cluster $$(domainname) --service-node $$(hostname)'
+    volumes:
+      - ./envoy/envoy.yaml:/etc/envoy.yaml:z,ro
+    expose:
+      - "8080"
+      - "9001"
+    ports:
+      - "8080"
+      - "9001"
+    scale: 2
+    domainname: "ingress"
+    networks:
+      - ingress
+      - control-plane
+      - jaeger
+      - mesh
+
+  web:
+    image: katacoda/docker-http-server
+    expose:
+      - "80"
+    ports:
+      - "80"
+    scale: 4
+    domainname: "app"
+    networks:
+      mesh:
+        aliases:
+          - app
+
+  control-plane:
+    build:
+      context: ..
+      dockerfile: ./compose/control-plane/Dockerfile
+    image: control-plane
+    volumes:
+      - ./control-plane/config.json:/home/app/bin/log.json:z,ro
+    expose:
+      - "5000"
+    ports:
+      - "5000:5000"
+    networks:
+      - control-plane
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    environment:
+      COLLECTOR_ZIPKIN_HTTP_PORT: "9411"
+    expose:
+      - "5775/udp"
+      - "6831-6832/udp"
+      - "5778"
+      - "16686"
+      - "14268"
+      - "14250"
+      - "9411"
+    ports:
+      - "16686:16686"
+    networks:
+      - jaeger
+
+networks:
+  control-plane:
+  ingress:
+  mesh:
+  jaeger:

--- a/compose/envoy/envoy.yaml
+++ b/compose/envoy/envoy.yaml
@@ -1,0 +1,56 @@
+dynamic_resources:
+  cds_config:
+    api_config_source:
+      api_type: grpc
+      grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
+
+static_resources:
+  clusters:
+    - name: xds_cluster
+      connect_timeout: 0.25s
+      type: strict_dns
+      lb_policy: round_robin
+      http2_protocol_options: {}
+      upstream_connection_options:
+        # configure a TCP keep-alive to detect and reconnect to the admin
+        # server in the event of a TCP socket half open connection
+        tcp_keepalive: {}
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: control-plane
+                  port_value: 443
+    - name: jaeger
+      connect_timeout: 0.5s
+      type: strict_dns
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: jaeger
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: jaeger
+                  port_value: 9411
+                  protocol: tcp
+
+tracing:
+  http:
+    name: envoy.tracers.zipkin
+    config:
+      collector_cluster: jaeger
+      collector_endpoint: "/api/v1/spans"
+
+admin:
+  access_log_path: /dev/stdout
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9001


### PR DESCRIPTION
This PR adds an (initial) environment for dev/test usable from the `make` tool, with some minimal support for contacting specific services a-la poor-man's `kubectl proxy`.

Pieces that should come later include fixing the control plane itself and adding more configuration to it including a WASM module.