### PR TITLE
workflows/{ci,clippy}: use stable toolchain for clippy and no longer allow nightly to cancel stable/beta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,18 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.required }}
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
           - beta
-          - nightly
           #- 1.45.2 # MSRV has not been defined for this project
+        required: [true]
+        include:
+          - rust: nightly
+            required: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             # Note: tonic_build will use rustfmt to format generated code
             components: clippy, rustfmt
             override: true

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 # Note: audit statuses are only triggered in specific cases, so can't use here
-status = ["ci (stable)", "ci (beta)", "clippy", "clippy_check"]
-pr_status = ["ci (stable)", "ci (beta)", "clippy", "clippy_check"]
+status = ["ci (stable, true)", "ci (beta, true)", "clippy", "clippy_check"]
+pr_status = ["ci (stable, true)", "ci (beta, true)", "clippy", "clippy_check"]
 delete_merged_branches = true
 use_codeowners = true
 use_squash_merge = false


### PR DESCRIPTION
Nightly broke today because the cargo component has a wrong checksum.