### PR TITLE
workflows/{clippy,audit}: enable on pull requests

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -6,6 +6,10 @@ on:
       - '**/Cargo.lock'
     branches-ignore:
       - '**.tmp'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
 
 jobs:
   audit_check:

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - '**.tmp'
+  pull_request:
 
 jobs:
   clippy_check:


### PR DESCRIPTION
This enables clippy and cargo audit on `pull_request` events too. It seems these apply to people opening PRs from other repos, as opposed to just generating a `push` event.