### PR TITLE
bors.toml: require clippy_check only to work around forked repo issue

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 # Note: audit statuses are only triggered in specific cases, so can't use here
-status = ["ci (stable, true)", "ci (beta, true)", "clippy", "clippy_check"]
-pr_status = ["ci (stable, true)", "ci (beta, true)", "clippy", "clippy_check"]
+status = ["ci (stable, true)", "ci (beta, true)", "clippy_check"]
+pr_status = ["ci (stable, true)", "ci (beta, true)", "clippy_check"]
 delete_merged_branches = true
 use_codeowners = true
 use_squash_merge = false


### PR DESCRIPTION
Currently the clippy CI action won't set a status for the whole workflow when a PR is created from a forked repo. This is a known
issue there, but we don't really require the whole workflow since it only contains a single job, so let's just require that one.