### PR TITLE
Config: Fix deadlock on config load

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -40,14 +40,6 @@ impl MasterProcess {
             //@TODO to delete  this wait until process start.
             std::thread::sleep(std::time::Duration::from_secs(3));
 
-            //@TODO remove this debug section.
-            let cfg = self.config.read().unwrap();
-            println!(
-                "Config--GetServices {:?} {:?}",
-                cfg.get_services(),
-                cfg.get_version()
-            );
-
             fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
                 println!("Intercepting request: {:?}", req);
                 Ok(req)


### PR DESCRIPTION
When config changed, the writer lock cannot be adquired because was hold
by the start function.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>