### PR TITLE
gitignore: ignore directories for vscode and clion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/target
+/.idea/
+/.vscode/
+/target/
 /tarpaulin_report.html
 # Generated protobuffers
-/src/protobuf
+/src/protobuf/


### PR DESCRIPTION
While at it also ensure directories are terminated with a forward slash.