### PR TITLE
Allow using docker-compose with a local control plane or a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPOSEFILE := $(PROJECT_PATH)/compose/docker-compose.yaml
 DOCKER_COMPOSE := docker-compose -f $(COMPOSEFILE)
 OPEN_APP ?= xdg-open
 
-.PHONY: fetch-protos help up stop status top kill down proxy-info proxy
+.PHONY: fetch-protos doc help up up-container up-local stop status top kill down proxy-info proxy
 
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 fetch_protos: ## Fetch protobuf files
@@ -13,8 +13,28 @@ fetch_protos: ## Fetch protobuf files
 doc: ## open project documentation
 	$(Q) cargo doc --open
 
-up: ## Start docker-compose containers
+
+up-container: export CONTROL_PLANE_LOCAL=control-plane-alt
+up-container: export CONTROL_PLANE_DOCKER=control-plane-main
+up-container: # Launch docker-compose with the control-plane as a container
+	@echo "Launch mode: control-plane in container (use LOCAL_CP=y to use localhost)"
 	$(DOCKER_COMPOSE) up
+
+up-local: export CONTROL_PLANE_LOCAL=control-plane-main
+up-local: export CONTROL_PLANE_DOCKER=control-plane-alt
+up-local: # Launch docker-compose with the control-plane as a (pre-existing) local process
+	@echo "Launch mode: control-plane in localhost (use LOCAL_CP=n to use a container)"
+	$(DOCKER_COMPOSE) up
+
+up-deps =
+
+ifeq ($(LOCAL_CP),y)
+	up-deps = up-local
+else
+	up-deps = up-container
+endif
+
+up: $(up-deps) ## Start docker-compose containers
 
 stop: ## Stop docker-compose containers
 	$(DOCKER_COMPOSE) stop

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -1,23 +1,27 @@
 version: "2.2"
 services:
   ingress:
-    image: istio/proxyv2:1.7.2
-    entrypoint: /bin/bash -c '/usr/local/bin/envoy -c /etc/envoy.yaml --service-cluster $$(domainname) --service-node $$(hostname)'
+    image: istio/proxyv2:1.7.3
+    entrypoint: /bin/bash -c 'sleep 5 && /usr/local/bin/envoy -c /etc/envoy.yaml --service-cluster $$(domainname) --service-node $$(hostname) --log-level debug'
     volumes:
-      - ./envoy/envoy.yaml:/etc/envoy.yaml:z,ro
+      - ${ENVOY_CONFIG:-./envoy/envoy.yaml}:/etc/envoy.yaml:z,ro
     expose:
       - "8080"
-      - "9001"
+      - "8001"
     ports:
       - "8080"
-      - "9001"
-    scale: 2
+      - "8001"
+    scale: 1
     domainname: "ingress"
+    depends_on:
+      control-plane:
+        condition: service_started
     networks:
       - ingress
       - control-plane
-      - jaeger
       - mesh
+    extra_hosts:
+      - "${CONTROL_PLANE_LOCAL:-control-plane-alt}:${CONTROL_PLANE_LOCAL_ADDR:-172.17.0.1}"
 
   web:
     image: katacoda/docker-http-server
@@ -42,29 +46,14 @@ services:
     expose:
       - "5000"
     ports:
-      - "5000:5000"
+      # export locally as 5001 to allow running a debug service at 5000
+      - "5001:5000"
     networks:
-      - control-plane
-
-  jaeger:
-    image: jaegertracing/all-in-one
-    environment:
-      COLLECTOR_ZIPKIN_HTTP_PORT: "9411"
-    expose:
-      - "5775/udp"
-      - "6831-6832/udp"
-      - "5778"
-      - "16686"
-      - "14268"
-      - "14250"
-      - "9411"
-    ports:
-      - "16686:16686"
-    networks:
-      - jaeger
+      control-plane:
+        aliases:
+          - ${CONTROL_PLANE_DOCKER:-control-plane-main}
 
 networks:
   control-plane:
   ingress:
   mesh:
-  jaeger:

--- a/compose/envoy/envoy.yaml
+++ b/compose/envoy/envoy.yaml
@@ -1,7 +1,9 @@
 dynamic_resources:
   cds_config:
+    resource_api_version: v3
     api_config_source:
       api_type: grpc
+      transport_api_version: v3
       grpc_services:
         - envoy_grpc:
             cluster_name: xds_cluster
@@ -9,7 +11,7 @@ dynamic_resources:
 static_resources:
   clusters:
     - name: xds_cluster
-      connect_timeout: 0.25s
+      connect_timeout: 2.0s
       type: logical_dns
       dns_refresh_rate: 60s
       lb_policy: round_robin
@@ -21,37 +23,16 @@ static_resources:
       load_assignment:
         cluster_name: xds_cluster
         endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: control-plane
-                  port_value: 5000
-    - name: jaeger
-      connect_timeout: 0.5s
-      type: strict_dns
-      lb_policy: round_robin
-      load_assignment:
-        cluster_name: jaeger
-        endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: jaeger
-                  port_value: 9411
-                  protocol: tcp
-
-tracing:
-  http:
-    name: envoy.tracers.zipkin
-    config:
-      collector_cluster: jaeger
-      collector_endpoint: "/api/v1/spans"
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: control-plane-main
+                      port_value: 5000
 
 admin:
   access_log_path: /dev/stdout
   address:
     socket_address:
       address: 0.0.0.0
-      port_value: 9001
+      port_value: 8001

--- a/log.json
+++ b/log.json
@@ -1,0 +1,1 @@
+compose/control-plane/config.json


### PR DESCRIPTION
Just use:

```shell
$ make LOCAL_CP=y up
```

after launching the project via `cargo run` locally listening on port `5000`, and the Envoy in docker-compose will connect to it. Otherwise the containerised image will be used as control plane.

You can also specify which `envoy.yaml` file to load (independently of using `LOCAL_CP` or not) by using:

```shell
$ make ENVOY_CONFIG=./envoy/envoy_file.yaml up
```

Note: relative paths are based off the `compose` directory, ie. where `docker-compose.yaml` resides.