### PR TITLE
Increase DNS refresh rates of xDS cluster and config clusters to reduce Envoy spamming logs

### DIFF
--- a/compose/envoy/envoy.yaml
+++ b/compose/envoy/envoy.yaml
@@ -10,7 +10,8 @@ static_resources:
   clusters:
     - name: xds_cluster
       connect_timeout: 0.25s
-      type: strict_dns
+      type: logical_dns
+      dns_refresh_rate: 60s
       lb_policy: round_robin
       http2_protocol_options: {}
       upstream_connection_options:

--- a/src/service.rs
+++ b/src/service.rs
@@ -90,6 +90,7 @@ impl Service {
                 nanos: 0,
             }),
             cluster_discovery_type: Some(ClusterDiscoveryType::Type(2)),
+            dns_refresh_rate: Some(core::time::Duration::from_secs(60).into()),
             // lb_policy: DiscoveryType::LogicalDns(),
             load_assignment: Some(ClusterLoadAssignment {
                 cluster_name: self.cluster_name(),


### PR DESCRIPTION
At debug level Envoy logs all its attempts to refresh DNS entries for clusters, and defaulting to 5s means the logs get very verbose very quickly. Setting a default of 60s for both makes for more readable traces.