### PR TITLE
Quick ingress access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ COMPOSEFILE := $(PROJECT_PATH)/compose/docker-compose.yaml
 DOCKER_COMPOSE := docker-compose -f $(COMPOSEFILE)
 OPEN_APP ?= xdg-open
 
-.PHONY: fetch-protos doc help up up-container up-local stop status top kill down proxy-info proxy
+.PHONY: fetch-protos doc help up up-container up-local stop status top kill \
+	down proxy-info proxy ingress-helper ingress-url ingress-open \
+	ingress-admin-url ingress-admin-open curl
 
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 fetch_protos: ## Fetch protobuf files
@@ -55,11 +57,46 @@ proxy-info: export INDEX?=1
 proxy-info: ## Obtain the local host address and port for a service (use SERVICE, PORT and optionally INDEX)
 	$(DOCKER_COMPOSE) port --index $(INDEX) $(SERVICE) $(PORT)
 
+proxy-url: export INDEX?=1
+proxy-url: export SCHEME?=http
+proxy-url: ## Obtain a URL for the given service (use SERVICE, PORT and optionally INDEX)
+	$(DOCKER_COMPOSE) port --index $(INDEX) $(SERVICE) $(PORT)
+
 proxy: export INDEX?=1
 proxy: export SCHEME?=http
 proxy: LOCALURL=$(shell $(DOCKER_COMPOSE) port --index $(INDEX) $(SERVICE) $(PORT))
 proxy: ## Open service and port in a browser (same as proxy-info, but optionally define SCHEME and OPEN_APP)
 	$(OPEN_APP) $(SCHEME)://$(LOCALURL)
+
+ingress-helper: export SERVICE?=ingress
+ingress-helper: export PORT?=80
+ingress-helper: export TARGET?=proxy-url
+ingress-helper:
+	$(MAKE) $(TARGET)
+
+ingress-url: ## Show the ingress URL
+	$(MAKE) ingress-helper
+
+ingress-open: export TARGET?=proxy
+ingress-open: ## Open the ingress URL
+	$(MAKE) ingress-helper
+
+ingress-admin-url: export PORT?=8001
+ingress-admin-url: ## Show the ingress admin URL
+	$(MAKE) ingress-helper
+
+ingress-admin-open: export PORT?=8001
+ingress-admin-open: export TARGET?=proxy
+ingress-admin-open: ## Open the ingress admin URL
+	$(MAKE) ingress-helper
+
+curl: export SCHEME?=http
+curl: export SERVICE?=ingress
+curl: export INDEX?=1
+curl: export PORT?=80
+curl: export HOST?=web.app
+curl: ## Perform a request to a specific service (default ingress:80 with Host: web.app)
+	curl -vvv -H "Host: $(HOST)" "$(SCHEME)://$$($(DOCKER_COMPOSE) port --index $(INDEX) $(SERVICE) $(PORT))/"
 
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/compose/control-plane/config.json
+++ b/compose/control-plane/config.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "hosts": ["web"],
+    "hosts": ["web", "web.app"],
     "policies": [],
     "target_domain": "web.app:80"
   }

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
       mesh:
         aliases:
           - app
+          - web.app
 
   control-plane:
     build:

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -6,9 +6,13 @@ services:
     volumes:
       - ${ENVOY_CONFIG:-./envoy/envoy.yaml}:/etc/envoy.yaml:z,ro
     expose:
+      - "80"
+      - "443"
       - "8080"
       - "8001"
     ports:
+      - "80"
+      - "443"
       - "8080"
       - "8001"
     scale: 1


### PR DESCRIPTION
This adds `make` helpers to quickly show/open the Envoy admin page and the ingress at port 80.

```shell
$ make ingress-open ingress-admin-open
```
or
```shell
$ make ingress-url ingress-admin-url
```

A quick smoke test can also be done with:

```shell
$ make curl
```

You can use variables `HOST` (defaults to what we have in the config file, `web.app`), `SCHEME` (`http`), `PORT` (`80`), `SERVICE` (`ingress`), `INDEX` (`1`, use `2`+ if scaling a service with multiple instances, such as `web`).