### PR TITLE
configuration: specify which file we tried to load when erroring

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -57,7 +57,7 @@ impl Config {
     fn read_path(&self, path: &str) -> std::string::String {
         let mut file = match File::open(path) {
             Ok(file) => file,
-            Err(error) => panic!("There was a problem opening the file: {:?}", error),
+            Err(error) => panic!("There was a problem opening the file {}: {:?}", path, error),
         };
         let mut contents = String::new();
         file.read_to_string(&mut contents)


### PR DESCRIPTION
Currently it just says it can't read a file, but not which one. Also - panicking in this thread does not terminate the program, which is what we likely want, but it's not important at this point.