### PR TITLE
service: bubble errors up and show causes

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -78,7 +78,11 @@ impl Config {
             errorlist
                 .into_iter()
                 .map(Result::unwrap_err)
-                .for_each(|err| log::error!("-> {}", err));
+                .for_each(|err| {
+                    // Print extended error information with causes
+                    // Will also print backtrace if enabled via envvar on nightly
+                    log::error!("-> {:?}", err);
+                });
         }
 
         let mut result = Vec::with_capacity(exportlist.len());


### PR DESCRIPTION
This will avoid panicking in the current code paths to export the configuration, and will also help pinpoint error causes. Ie. when the wasm filter is not present, you'll now see:

```
[2020-10-22T23:26:14Z ERROR gateway_ng_controller::configuration] -> failed to export listener for service 1
    
    Caused by:
        0: could not compute SHA-256
        1: failed to open wasm filter: static/filter.wasm
        2: No such file or directory (os error 2)
```