### PR TITLE
workflows/ci: sync with template

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.required }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,10 +22,11 @@ jobs:
           - stable
           - beta
           #- 1.45.2 # MSRV has not been defined for this project
-        required: [true]
+        experimental: [false]
         include:
+          # Stop breakages in nightly to fail the workflow
           - rust: nightly
-            required: false
+            experimental: true
 
     steps:
       - uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 # Note: audit statuses are only triggered in specific cases, so can't use here
-status = ["ci (stable, true)", "ci (beta, true)", "clippy_check"]
-pr_status = ["ci (stable, true)", "ci (beta, true)", "clippy_check"]
+status = ["ci (stable, false)", "ci (beta, false)", "clippy_check"]
+pr_status = ["ci (stable, false)", "ci (beta, false)", "clippy_check"]
 delete_merged_branches = true
 use_codeowners = true
 use_squash_merge = false


### PR DESCRIPTION
Sync CI workflow with the template project.

We not only rename 'required' to 'experimental', but also fix the error that effectively makes it work backwards.