### PR TITLE
Wasm: Stop execution.

### DIFF
--- a/wasm_filter/src/lib.rs
+++ b/wasm_filter/src/lib.rs
@@ -89,9 +89,9 @@ impl HttpContext for HttpHeaders {
             config.match_mapping_rule(self.get_method().unwrap(), self.get_path().unwrap());
         if !status {
             self.send_http_response(403, vec![], Some(b"Mapping rule not found\n"));
-            return Action::Pause;
+        } else {
+            self.authrep(metrics);
         }
-        self.authrep(metrics);
         Action::Pause
     }
 

--- a/wasm_filter/src/lib.rs
+++ b/wasm_filter/src/lib.rs
@@ -89,7 +89,7 @@ impl HttpContext for HttpHeaders {
             config.match_mapping_rule(self.get_method().unwrap(), self.get_path().unwrap());
         if !status {
             self.send_http_response(403, vec![], Some(b"Mapping rule not found\n"));
-            return Action::Continue;
+            return Action::Pause;
         }
         self.authrep(metrics);
         Action::Pause


### PR DESCRIPTION
When send_respose is sent, the process should be stopped(Action::Pause)
if not the proxy will die with a core-dump

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>