### PR TITLE
WASM: Add JWT policy

### DIFF
--- a/compose/control-plane/config.json
+++ b/compose/control-plane/config.json
@@ -5,6 +5,20 @@
     "policies": [],
     "target_domain": "http://web.app:80",
     "oidc_issuer": "http://keycloak:8080/auth/realms/ostia",
+    "hosts": [
+      "web",
+      "web.app"
+    ],
+    "policies": [
+      {
+        "name": "jwt",
+        "configuration": {
+          "rules": [
+            "AA"
+          ]
+        }
+      }
+    ],
     "proxy_rules": [
       {
         "pattern": "/",

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -78,6 +78,7 @@ impl OIDCConfig {
 
         let provider = JwtProvider {
             issuer: self.issuer.clone(),
+            payload_in_metadata: "jwt_payload".to_string(),
             from_headers: vec![JwtHeader {
                 name: "Authorization".to_string(),
                 value_prefix: "Bearer ".to_string(),

--- a/src/service.rs
+++ b/src/service.rs
@@ -52,11 +52,17 @@ pub struct MappingRules {
     delta: u32,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct PoliciyConfig {
+    pub name: String,
+    configuration: serde_json::Value,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Service {
     pub id: u32,
     pub hosts: Vec<std::string::String>,
-    pub policies: Vec<std::string::String>,
+    pub policies: Vec<PoliciyConfig>,
     pub target_domain: std::string::String,
     pub proxy_rules: Vec<MappingRules>,
     pub oidc_issuer: std::string::String,

--- a/wasm_filter/Cargo.lock
+++ b/wasm_filter/Cargo.lock
@@ -19,12 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,7 +48,6 @@ name = "filter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
  "chrono",
  "log",
  "proxy-wasm",

--- a/wasm_filter/Cargo.lock
+++ b/wasm_filter/Cargo.lock
@@ -7,10 +7,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
+name = "anyhow"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bumpalo"
@@ -41,6 +53,8 @@ dependencies = [
 name = "filter"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "base64",
  "chrono",
  "log",
  "proxy-wasm",

--- a/wasm_filter/Cargo.lock
+++ b/wasm_filter/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,12 +50,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "filter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
  "log",
+ "prost",
+ "prost-types",
  "proxy-wasm",
  "serde",
  "serde_json",
@@ -65,6 +79,15 @@ checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
 dependencies = [
  "ahash",
  "autocfg",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -126,6 +149,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]

--- a/wasm_filter/Cargo.toml
+++ b/wasm_filter/Cargo.toml
@@ -15,5 +15,8 @@ serde = { version = "^1", features = ["derive"] }
 
 anyhow = "^1"
 
+prost = { version = "^0", default-features = false, features = ["prost-derive"] }
+prost-types = { version = "^0", default-features = false }
+
 [lib]
 crate-type = ["cdylib"]

--- a/wasm_filter/Cargo.toml
+++ b/wasm_filter/Cargo.toml
@@ -13,5 +13,8 @@ wasm-bindgen-macro = "0.2.60"
 serde_json = "^1"
 serde = { version = "^1", features = ["derive"] }
 
+anyhow = "^1"
+base64 = "0.13.0"
+
 [lib]
 crate-type = ["cdylib"]

--- a/wasm_filter/Cargo.toml
+++ b/wasm_filter/Cargo.toml
@@ -14,7 +14,6 @@ serde_json = "^1"
 serde = { version = "^1", features = ["derive"] }
 
 anyhow = "^1"
-base64 = "0.13.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/wasm_filter/src/config.rs
+++ b/wasm_filter/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -31,10 +32,16 @@ impl MappingRule {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct PoliciyConfig {
+    pub name: String,
+    configuration: serde_json::Value,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Service {
     pub id: u32,
     pub hosts: Vec<String>,
-    pub policies: Vec<String>,
+    pub policies: Vec<PoliciyConfig>,
     pub target_domain: String,
     pub proxy_rules: Vec<MappingRule>,
 }

--- a/wasm_filter/src/jwt.rs
+++ b/wasm_filter/src/jwt.rs
@@ -1,6 +1,8 @@
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
 
+use prost::Message;
+
 #[derive(Debug, Default)]
 pub struct Rules {
     path: String,
@@ -94,7 +96,15 @@ impl JWT {
         if data.is_none() {
             return Err(anyhow::Error::msg("Failed to get JWT payload"));
         }
-
+        log::info!("Bytes --> {:?}", data.clone().unwrap().as_slice());
+        log::info!(
+            "STR --> {:?}",
+            std::str::from_utf8(data.clone().unwrap().as_slice())
+        );
+        let msg: prost_types::Struct =
+            Message::decode_length_delimited(data.clone().unwrap().as_slice())
+                .expect("cannot decode message");
+        log::info!("MSG--> {:?}", msg);
         return Ok(data.unwrap());
     }
 

--- a/wasm_filter/src/jwt.rs
+++ b/wasm_filter/src/jwt.rs
@@ -1,0 +1,126 @@
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+
+use base64::decode;
+
+#[derive(Debug, Default)]
+pub struct Rules {
+    path: String,
+    claim: String,       // Move to liquid
+    claim_value: String, // Move to liquid
+    allow: bool,
+}
+impl Rules {
+    pub fn matches(&self, path: String, jwt: PayloadType) -> bool {
+        if self.path != path {
+            return false;
+        }
+        match jwt.get(self.claim.as_str()) {
+            None => false,
+            Some(j) => {
+                // @TODO at some point of time, this should be a liquid template.
+                if j.as_str().unwrap() == self.claim_value.as_str() {
+                    return true;
+                }
+                false
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct JWTConfig {
+    pub rules: Vec<Rules>,
+}
+
+#[derive(Debug, Default)]
+pub struct JWT {
+    pub context_id: u32,
+    pub config: JWTConfig,
+}
+
+pub type PayloadType = std::collections::HashMap<String, serde_json::Value>;
+
+impl JWT {
+    pub fn new(context_id: u32) -> JWT {
+        JWT {
+            context_id,
+            config: JWTConfig {
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn config(&mut self) {
+        self.config.rules = Vec::new();
+        self.config.rules.push(Rules {
+            path: "/headers".to_string(),
+            claim: "name".to_string(),
+            claim_value: "John Doe".to_string(),
+            allow: false,
+        });
+    }
+
+    pub fn get_jwt_token(&self) -> Result<PayloadType, anyhow::Error> {
+        // @TODO: This is a shit-show! Sorry!
+        // This should be changed in two different ways:
+        // 1) and for me, the best one, is to be able to read this property from envoy.
+        // https://github.com/envoyproxy/envoy/blob/bd73f3c4da0efffb2593d7c9ecf87788856dc052/source/extensions/filters/http/jwt_authn/filter.cc#L104
+        // 2) Use any decoder from any crate, and here we have the problems with SSL* things, that
+        //    are not available on Envoy.
+        //
+        // as you can imagine, the verification happens on jwt_authn filter :-)
+        let raw_header = self.get_http_request_header("Authorization");
+        if raw_header.is_none() {
+            return Err(anyhow::Error::msg("Failed to get Bearer token"));
+        }
+
+        let s = raw_header.unwrap();
+        let result: Vec<_> = s.split_whitespace().collect();
+        if result.len() != 2 {
+            return Err(anyhow::Error::msg("Failed to extract bearer token"));
+        }
+
+        let decoded_token: Vec<_> = result.get(1).unwrap().split(".").collect();
+        let raw_payload = decode(decoded_token.get(1).unwrap())?;
+
+        let payload: PayloadType = serde_json::from_slice(raw_payload.as_slice())?;
+
+        return Ok(payload);
+    }
+
+    fn get_path(&self) -> Option<std::string::String> {
+        return self.get_http_request_header(":path");
+    }
+}
+
+impl Context for JWT {}
+
+impl HttpContext for JWT {
+    fn on_http_request_headers(&mut self, _: usize) -> Action {
+        // @TODO to be removed until HTTP_CONTEXT can have metadata attached
+        self.config();
+
+        let jwt_token = self.get_jwt_token();
+        if jwt_token.is_err() {
+            log::warn!("Error on JWT auth: '{:?}'", jwt_token);
+            self.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
+            return Action::Pause;
+        }
+        let token = jwt_token.unwrap();
+        let mut result = false;
+
+        for rule in &self.config.rules {
+            if rule.matches(self.get_path().unwrap(), token.clone()) {
+                result = true;
+            }
+        }
+
+        if result == true {
+            return Action::Continue;
+        }
+
+        self.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
+        return Action::Pause;
+    }
+}

--- a/wasm_filter/src/jwt.rs
+++ b/wasm_filter/src/jwt.rs
@@ -1,8 +1,6 @@
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
 
-use base64::decode;
-
 #[derive(Debug, Default)]
 pub struct Rules {
     path: String,
@@ -11,20 +9,25 @@ pub struct Rules {
     allow: bool,
 }
 impl Rules {
-    pub fn matches(&self, path: String, jwt: PayloadType) -> bool {
+    pub fn matches(&self, path: String, jwt_claim_value: &str) -> bool {
         if self.path != path {
+            log::debug!(
+                "PATH failed match request_path='{}' with path='{}'",
+                self.path,
+                path
+            );
             return false;
         }
-        match jwt.get(self.claim.as_str()) {
-            None => false,
-            Some(j) => {
-                // @TODO at some point of time, this should be a liquid template.
-                if j.as_str().unwrap() == self.claim_value.as_str() {
-                    return true;
-                }
-                false
-            }
+        if self.claim_value.as_str() != jwt_claim_value {
+            log::debug!(
+                "Matches claim_value='{}' with jwt_value='{}' failed",
+                self.claim_value,
+                jwt_claim_value,
+            );
+            return false;
         }
+
+        true
     }
 }
 
@@ -38,8 +41,6 @@ pub struct JWT {
     pub context_id: u32,
     pub config: JWTConfig,
 }
-
-pub type PayloadType = std::collections::HashMap<String, serde_json::Value>;
 
 impl JWT {
     pub fn new(context_id: u32) -> JWT {
@@ -56,37 +57,45 @@ impl JWT {
         self.config.rules.push(Rules {
             path: "/headers".to_string(),
             claim: "name".to_string(),
-            claim_value: "John Doe".to_string(),
+            claim_value: "Jane Smith".to_string(),
             allow: false,
         });
     }
+    pub fn get_jwt_claim(&self, claim: &str) -> Result<String, anyhow::Error> {
+        let key = vec![
+            "metadata",
+            "filter_metadata",
+            "envoy.filters.http.jwt_authn",
+            "jwt_payload",
+            claim,
+        ];
 
-    pub fn get_jwt_token(&self) -> Result<PayloadType, anyhow::Error> {
-        // @TODO: This is a shit-show! Sorry!
-        // This should be changed in two different ways:
-        // 1) and for me, the best one, is to be able to read this property from envoy.
-        // https://github.com/envoyproxy/envoy/blob/bd73f3c4da0efffb2593d7c9ecf87788856dc052/source/extensions/filters/http/jwt_authn/filter.cc#L104
-        // 2) Use any decoder from any crate, and here we have the problems with SSL* things, that
-        //    are not available on Envoy.
-        //
-        // as you can imagine, the verification happens on jwt_authn filter :-)
-        let raw_header = self.get_http_request_header("Authorization");
-        if raw_header.is_none() {
-            return Err(anyhow::Error::msg("Failed to get Bearer token"));
+        let data = self.get_property(key);
+        if data.is_none() {
+            return Err(anyhow::Error::msg("Failed to get JWT payload"));
+        }
+        let tmp = data.clone().unwrap();
+
+        let ret = std::str::from_utf8(tmp.as_slice());
+        if ret.is_err() {
+            return Err(anyhow::Error::msg("Failed to get decode JWT payload"));
+        }
+        Ok(ret.unwrap().to_string())
+    }
+
+    pub fn get_jwt_token(&self) -> Result<Vec<u8>, anyhow::Error> {
+        let data = self.get_property(vec![
+            "metadata",
+            "filter_metadata",
+            "envoy.filters.http.jwt_authn",
+            "jwt_payload",
+        ]);
+
+        if data.is_none() {
+            return Err(anyhow::Error::msg("Failed to get JWT payload"));
         }
 
-        let s = raw_header.unwrap();
-        let result: Vec<_> = s.split_whitespace().collect();
-        if result.len() != 2 {
-            return Err(anyhow::Error::msg("Failed to extract bearer token"));
-        }
-
-        let decoded_token: Vec<_> = result.get(1).unwrap().split(".").collect();
-        let raw_payload = decode(decoded_token.get(1).unwrap())?;
-
-        let payload: PayloadType = serde_json::from_slice(raw_payload.as_slice())?;
-
-        return Ok(payload);
+        return Ok(data.unwrap());
     }
 
     fn get_path(&self) -> Option<std::string::String> {
@@ -107,11 +116,17 @@ impl HttpContext for JWT {
             self.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
             return Action::Pause;
         }
-        let token = jwt_token.unwrap();
+
         let mut result = false;
 
         for rule in &self.config.rules {
-            if rule.matches(self.get_path().unwrap(), token.clone()) {
+            let claim_value = self.get_jwt_claim(rule.claim.as_str());
+            if claim_value.is_err() {
+                log::info!("Cannot retrieve {}", rule.claim.as_str());
+                continue;
+            }
+
+            if rule.matches(self.get_path().unwrap(), claim_value.unwrap().as_str()) {
                 result = true;
             }
         }


### PR DESCRIPTION
This is a dirty commit POC around implementation of a policy, there are a lot
of hardcoded things, and these are the reason:

-> On a new filter on rust, no way to share metadata. So config should
be hardcoded, PR to change that in upstream is already open.
-> On JWT parsing, there is no way to get the value from Envoy, shared
metadata, etc.. so need to work on decode that, all the libraries are
using SSL libs, and WASM cannot be started if enabled.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>