### PR TITLE
Add 3scale wasm auth filter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "protos/envoyproxy/protoc-gen-validate"]
 	path = protos/envoyproxy/protoc-gen-validate
 	url = https://github.com/envoyproxy/protoc-gen-validate
+[submodule "threescale-wasm-auth"]
+	path = threescale-wasm-auth
+	url = https://github.com/3scale-rs/threescale-wasm-auth

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,13 +1722,15 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ anyhow = "^1"
 warp = "0.2.5"
 ring = "0.16.15"
 data-encoding = "2.3.0"
-url= "2.1.1"
+url= { version = "^2.2", features = ["serde"] }
 
 curl = "0.4.34"
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,19 @@ update_protos: ##  Update Protobuf files
 
 .PHONY: wasm_build
 wasm_build: ## Build wasm filter
-	$(Q) cargo build --target=wasm32-unknown-unknown --lib --manifest-path wasm_filter/Cargo.toml
-	$(Q) cp -fv wasm_filter/target/wasm32-unknown-unknown/debug/filter.wasm static/
+	$(Q) cargo build --target=wasm32-unknown-unknown --lib --manifest-path $(PROJECT_PATH)/wasm_filter/Cargo.toml
+	$(Q) cp -fv $(PROJECT_PATH)/wasm_filter/target/wasm32-unknown-unknown/debug/filter.wasm $(PROJECT_PATH)/static/
+
+.PHONY: auth-build
+auth-build: ## Build 3scale auth wasm filter
+	$(MAKE) -C $(PROJECT_PATH)/threescale-wasm-auth build
+	mkdir -p $(PROJECT_PATH)/compose/control-plane/static
+	cp -fv $(PROJECT_PATH)/threescale-wasm-auth/compose/wasm/threescale_wasm_auth.wasm $(PROJECT_PATH)/static/
+
+.PHONY: auth-build-clean
+auth-build-clean: ## Build 3scale auth wasm filter
+	rm -f $(PROJECT_PATH)/compose/control-plane/static/threescale_wasm_auth.wasm
+	$(MAKE) -C $(PROJECT_PATH)/threescale-wasm-auth clean
 
 doc: ## open project documentation
 	$(Q) cargo doc --open

--- a/compose/control-plane/config.json
+++ b/compose/control-plane/config.json
@@ -1,7 +1,10 @@
 [
   {
     "id": 1,
-    "hosts": ["web", "web.app"],
+    "hosts": [
+      "web",
+      "web.app"
+    ],
     "policies": [],
     "target_domain": "http://web.app:80",
     "oidc_issuer": "http://keycloak:8080/auth/realms/ostia",
@@ -18,6 +21,96 @@
         "metric_system_name": "hits",
         "delta": 1
       }
-    ]
+    ],
+    "auth_config": {
+      "path": "static/threescale_wasm_auth.wasm",
+      "wasm_config": {
+        "system": {
+          "cluster_name": "a_cluster",
+          "url": "https://a-system-url/",
+          "token": "a system token",
+          "timeout": 5
+        },
+        "backend": {
+          "cluster_name": "3scale-saas-backend",
+          "url": "https://su1.3scale.net/",
+          "timeout": 5
+        },
+        "services": [
+          {
+            "id": "web_svc_id",
+            "token": "web_svc_token",
+            "authorities": [
+              "web",
+              "web.app"
+            ],
+            "credentials": [
+              {
+                "kind": "user_key",
+                "key": "x-api-key",
+                "locations": [
+                  "header",
+                  "query_string"
+                ]
+              }
+            ],
+            "mapping_rules": [
+              {
+                "method": "get",
+                "pattern": "/",
+                "usages": [
+                  {
+                    "name": "hits",
+                    "delta": 1
+                  }
+                ]
+              },
+              {
+                "method": "get",
+                "pattern": "/ticks",
+                "usages": [
+                  {
+                    "name": "ticks",
+                    "delta": 1
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "echo_svc_id",
+            "token": "echo_svc_token",
+            "authorities": [
+              "echo-api",
+              "echo-api.app",
+              "echoapi",
+              "echoapi.app"
+            ],
+            "credentials": [
+              {
+                "kind": "user_key",
+                "key": "x-api-key",
+                "locations": [
+                  "header",
+                  "query_string"
+                ]
+              }
+            ],
+            "mapping_rules": [
+              {
+                "method": "get",
+                "pattern": "/",
+                "usages": [
+                  {
+                    "name": "hits",
+                    "delta": 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
   }
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod processor;
 #[rustfmt::skip]
 mod protobuf;
 mod service;
+mod threescale_auth;
 mod util;
 
 use processor::MasterProcess;

--- a/src/threescale_auth.rs
+++ b/src/threescale_auth.rs
@@ -1,0 +1,102 @@
+use crate::envoy_helpers::{encode, get_envoy_cluster};
+use crate::protobuf::envoy::config::cluster::v3::Cluster;
+use crate::protobuf::envoy::config::core::v3::async_data_source::Specifier;
+use crate::protobuf::envoy::config::core::v3::http_uri::HttpUpstreamType;
+use crate::protobuf::envoy::config::core::v3::AsyncDataSource;
+use crate::protobuf::envoy::config::core::v3::HttpUri;
+use crate::protobuf::envoy::config::core::v3::RemoteDataSource;
+use crate::protobuf::envoy::extensions::filters::http::wasm::v3::Wasm;
+use crate::protobuf::envoy::extensions::wasm::v3::plugin_config::Vm;
+use crate::protobuf::envoy::extensions::wasm::v3::{PluginConfig, VmConfig};
+use crate::service;
+use anyhow::{Context, Result};
+use prost_types::Duration;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Backend {
+    pub cluster_name: String,
+    pub url: url::Url,
+    #[serde(flatten)]
+    other: std::collections::HashMap<String, serde_json::Value>,
+}
+
+impl Backend {
+    pub fn cluster(&self) -> Result<Cluster> {
+        get_envoy_cluster(self.cluster_name.clone(), self.url.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreescaleAuth {
+    path: String,
+    wasm_config: WasmConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WasmConfig {
+    backend: Backend,
+    #[serde(flatten)]
+    other: std::collections::HashMap<String, serde_json::Value>,
+}
+
+impl ThreescaleAuth {
+    pub fn cluster(&self) -> Result<Cluster> {
+        self.wasm_config.backend.cluster()
+    }
+
+    pub fn build_wasm(&self, id: u32) -> Result<Wasm> {
+        let wasm_config_s = serde_json::to_string_pretty(&self.wasm_config)?;
+        get_wasm_filter(self.path.clone(), wasm_config_s.as_str(), id)
+    }
+}
+
+fn get_wasm_filter(path: impl AsRef<Path>, auth_config: &str, id: u32) -> Result<Wasm> {
+    let path = path.as_ref();
+    let filename = path
+        .file_name()
+        .with_context(|| format!("failed to obtain file name of {}", path.display()))?;
+    Ok(Wasm {
+        config: Some(PluginConfig {
+            name: format!("Service::{:?}", id),
+            root_id: format!("Service::{:?}", id),
+            vm: Some(Vm::VmConfig(VmConfig {
+                vm_id: format!("Service::{:?}", id),
+                runtime: "envoy.wasm.runtime.v8".to_string(),
+                configuration: Some(prost_types::Any {
+                    type_url: "type.googleapis.com/google.protobuf.StringValue".to_string(),
+                    value: encode("vm config".to_string())?,
+                }),
+                code: Some(AsyncDataSource {
+                    specifier: Some(Specifier::Remote(RemoteDataSource {
+                        http_uri: Some(HttpUri {
+                            uri: format!(
+                                "http://control-plane-main:5001/static/{}",
+                                filename
+                                    .to_str()
+                                    .context("invalid unicode in wasm file name")?
+                            ),
+                            timeout: Some(Duration {
+                                seconds: 100,
+                                nanos: 0,
+                            }),
+                            http_upstream_type: Some(HttpUpstreamType::Cluster(
+                                "wasm_files".to_string(),
+                            )),
+                        }),
+                        sha256: service::Service::get_wasm_filter_sha(path)
+                            .context("could not compute SHA-256")?,
+                        ..Default::default()
+                    })),
+                }),
+                ..Default::default()
+            })),
+            configuration: Some(prost_types::Any {
+                type_url: "type.googleapis.com/google.protobuf.StringValue".to_string(),
+                value: encode(auth_config.to_string())?,
+            }),
+            ..Default::default()
+        }),
+    })
+}


### PR DESCRIPTION
This adds an early version of the 3scale wasm authorization filter to the control plane.

The filter itself can do basic authorization using `user_key`s, and the patch basically adds the wasm filter and a cluster (for 3scale backend), as well as the configuration of the wasm filter itself.

The configuration actually needs the real service ids and tokens, and perhaps some curls like the ones existing in the filter repo.

This is a draft so far, but should be working at a basic level with an account in 3scale.